### PR TITLE
feat: new `restrict-dependency-ranges` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [require-name](docs/rules/require-name.md)                             | Requires the `name` property to be present.                                                       | ✔️ ✅ |    |    |    |
 | [require-types](docs/rules/require-types.md)                           | Requires the `types` property to be present.                                                      |      |    |    |    |
 | [require-version](docs/rules/require-version.md)                       | Requires the `version` property to be present.                                                    | ✔️ ✅ |    |    |    |
+| [restrict-dependency-ranges](docs/rules/restrict-dependency-ranges.md) | Restricts the range of dependencies to allow or disallow specific types of ranges.                |      |    | 💡 |    |
 | [sort-collections](docs/rules/sort-collections.md)                     | Dependencies, scripts, and configuration values must be declared in alphabetical order.           | ✔️ ✅ | 🔧 |    |    |
 | [unique-dependencies](docs/rules/unique-dependencies.md)               | Checks a dependency isn't specified more than once (i.e. in `dependencies` and `devDependencies`) | ✔️ ✅ |    | 💡 |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)         | Checks existence of local dependencies in the package.json                                        | ✔️ ✅ |    |    |    |

--- a/docs/rules/restrict-dependency-ranges.md
+++ b/docs/rules/restrict-dependency-ranges.md
@@ -1,0 +1,114 @@
+# restrict-dependency-ranges
+
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
+<!-- end auto-generated rule header -->
+
+This rule allows you to require that specific dependencies use a particular kind
+of semver range (e.g. `^`). There are several options for specifying which dependencies
+a range type restriction should be applied to, including dependency type,
+package name (or name regex pattern), and version range (e.g. '<1').
+
+If you provide multiple options and a dependency matches more than one of the
+options, the last option that matches will take precedent for that dependency.
+This allows you to define more general rules that apply to all dependencies (or large
+groups of dependencies), and then define more granular options to apply exceptions
+or focus on some subset of dependencies.
+
+## Options
+
+`type DependencyType = 'dependencies' | 'devDependencies' | 'optionalDependencies' | 'peerDependencies';`\
+`type RangeType = 'caret' | 'pin' | 'tilde';`
+
+| Name                 | Type                     | Required |
+| :------------------- | :----------------------- | :------- |
+| `forDependencyTypes` | DependencyType[]         |          |
+| `forPackages`        | String[]                 |          |
+| `forVersions`        | String                   |          |
+| `rangeType`          | RangeType \| RangeType[] | Yes      |
+
+You can provide a single options object consisting of the above, or an array
+of such objects.
+
+### `forDependencyTypes`
+
+You can use this to apply a range type restriction for an entire group of dependencies
+by which type of dependencies they belong to.
+
+Options are
+
+- dependencies
+- devDependencies
+- optionalDependencies
+- peerDependencies
+
+### `forPackages`
+
+This can be the exact name of a package, or a regex pattern used to match a
+group of packages by name (e.g. `@typescript-eslint/*`).
+
+### `forVersions`
+
+You can use this to apply a restriction to a specific semver range. For example,
+a common use case is to pin "unstable" dependencies (packages that have
+a version in the `0.x.x` range). You can do this by setting `forVersions` to `'<1'`.
+
+### `rangeType`
+
+This is the only required option, and identifies which range type or types you
+want to apply to packages that match any of the other match options (or all
+dependencies if no other options are provided).
+
+## Example
+
+```ts
+export default [
+	{
+		"package-json/restrict-dependency-ranges": [
+			"error",
+			[
+				// Apply base requirement that all deps should use ^
+				{
+					rangeType: "caret",
+				},
+
+				// Restrict typescript to tilde ranges
+				{
+					forPackages: "typescript",
+					rangeType: "tilde",
+				},
+
+				// Require packages that have 0.x.x versions are pinned
+				{
+					forVersions: "<1",
+					rangeType: "pin",
+				},
+			],
+		],
+	},
+];
+```
+
+Example of **incorrect** code for the above configuration:
+
+```json
+{
+	"devDependencies": {
+		"eslint": "^9.18.0",
+		"markdownlint": "^0.37.4",
+		"typescript": "^5.8.0"
+	}
+}
+```
+
+Example of **correct** code for the above configuration:
+
+```json
+{
+	"devDependencies": {
+		"eslint": "^9.18.0",
+		"markdownlint": "0.37.4",
+		"typescript": "~5.8.0"
+	}
+}
+```

--- a/docs/rules/restrict-dependency-ranges.md
+++ b/docs/rules/restrict-dependency-ranges.md
@@ -4,10 +4,8 @@
 
 <!-- end auto-generated rule header -->
 
-This rule allows you to require that specific dependencies use a particular kind
-of semver range (e.g. `^`). There are several options for specifying which dependencies
-a range type restriction should be applied to, including dependency type,
-package name (or name regex pattern), and version range (e.g. '<1').
+This rule allows you to require that specific dependencies use a particular kind of semver range (e.g. `^`).
+There are several options for specifying which dependencies a range type restriction should be applied to, including dependency type, package name (or name regex pattern), and version range (e.g. '<1').
 
 ```ts
 export default [
@@ -24,11 +22,8 @@ export default [
 ];
 ```
 
-If you provide multiple options and a dependency matches more than one of the
-options, the last option that matches will take precedent for that dependency.
-This allows you to define more general rules that apply to all dependencies (or large
-groups of dependencies), and then define more granular options to apply exceptions
-or focus on some subset of dependencies.
+If you provide multiple options and a dependency matches more than one of the options, the last option that matches will take precedent for that dependency.
+This allows you to define more general rules that apply to all dependencies (or large groups of dependencies), and then define more granular options to apply exceptions or focus on some subset of dependencies.
 
 ## Options
 
@@ -42,13 +37,11 @@ or focus on some subset of dependencies.
 | `forVersions`        | string                   |          |
 | `rangeType`          | RangeType \| RangeType[] | Yes      |
 
-You can provide a single options object consisting of the above, or an array
-of such objects.
+You can provide a single options object consisting of the above, or an array of such objects.
 
 ### `forDependencyTypes`
 
-You can use this to apply a range type restriction for an entire group of dependencies
-by which type of dependencies they belong to.
+You can use this to apply a range type restriction for an entire group of dependencies by which type of dependencies they belong to.
 
 Options are
 
@@ -74,8 +67,7 @@ export default [
 
 ### `forPackages`
 
-This can be the exact name of a package, or a regex pattern used to match a
-group of packages by name (e.g. `@typescript-eslint/*`).
+This can be the exact name of a package, or a regex pattern used to match a group of packages by name (e.g. `@typescript-eslint/*`).
 
 ```ts
 export default [
@@ -94,9 +86,9 @@ export default [
 
 ### `forVersions`
 
-You can use this to apply a restriction to a specific semver range. For example,
-a common use case is to pin "unstable" dependencies (packages that have
-a version in the `0.x.x` range). You can do this by setting `forVersions` to `'<1'`.
+You can use this to apply a restriction to a specific semver range.
+For example, a common use case is to pin "unstable" dependencies (packages that have a version in the `0.x.x` range).
+You can do this by setting `forVersions` to `'<1'`.
 
 ```ts
 export default [
@@ -114,9 +106,7 @@ export default [
 
 ### `rangeType`
 
-This is the only required option, and identifies which range type or types you
-want to apply to packages that match any of the other match options (or all
-dependencies if no other options are provided).
+This is the only required option, and identifies which range type or types you want to apply to packages that match any of the other match options (or all dependencies if no other options are provided).
 
 ```ts
 export default [

--- a/docs/rules/restrict-dependency-ranges.md
+++ b/docs/rules/restrict-dependency-ranges.md
@@ -9,6 +9,21 @@ of semver range (e.g. `^`). There are several options for specifying which depen
 a range type restriction should be applied to, including dependency type,
 package name (or name regex pattern), and version range (e.g. '<1').
 
+```ts
+export default [
+	{
+		"package-json/restrict-dependency-ranges": [
+			"error",
+			// Require that packages with 0.x.x versions are pinned
+			{
+				forVersions: "<1",
+				rangeType: "pin",
+			},
+		],
+	},
+];
+```
+
 If you provide multiple options and a dependency matches more than one of the
 options, the last option that matches will take precedent for that dependency.
 This allows you to define more general rules that apply to all dependencies (or large
@@ -23,8 +38,8 @@ or focus on some subset of dependencies.
 | Name                 | Type                     | Required |
 | :------------------- | :----------------------- | :------- |
 | `forDependencyTypes` | DependencyType[]         |          |
-| `forPackages`        | String[]                 |          |
-| `forVersions`        | String                   |          |
+| `forPackages`        | string[]                 |          |
+| `forVersions`        | string                   |          |
 | `rangeType`          | RangeType \| RangeType[] | Yes      |
 
 You can provide a single options object consisting of the above, or an array
@@ -42,10 +57,40 @@ Options are
 - optionalDependencies
 - peerDependencies
 
+```ts
+export default [
+	{
+		"package-json/restrict-dependency-ranges": [
+			"error",
+			// Require that all dev dependencies are pinned
+			{
+				forDependencyTypes: ["devDependencies"],
+				rangeType: "pin",
+			},
+		],
+	},
+];
+```
+
 ### `forPackages`
 
 This can be the exact name of a package, or a regex pattern used to match a
 group of packages by name (e.g. `@typescript-eslint/*`).
+
+```ts
+export default [
+	{
+		"package-json/restrict-dependency-ranges": [
+			"error",
+			// Restrict typescript to tilde ranges
+			{
+				forPackages: "typescript",
+				rangeType: "tilde",
+			},
+		],
+	},
+];
+```
 
 ### `forVersions`
 
@@ -53,11 +98,39 @@ You can use this to apply a restriction to a specific semver range. For example,
 a common use case is to pin "unstable" dependencies (packages that have
 a version in the `0.x.x` range). You can do this by setting `forVersions` to `'<1'`.
 
+```ts
+export default [
+	{
+		"package-json/restrict-dependency-ranges": [
+			"error",
+			// Require that all deps should use ^
+			{
+				rangeType: "caret",
+			},
+		],
+	},
+];
+```
+
 ### `rangeType`
 
 This is the only required option, and identifies which range type or types you
 want to apply to packages that match any of the other match options (or all
 dependencies if no other options are provided).
+
+```ts
+export default [
+	{
+		"package-json/restrict-dependency-ranges": [
+			"error",
+			// Require that all deps should use ^
+			{
+				rangeType: "caret",
+			},
+		],
+	},
+];
+```
 
 ## Example
 
@@ -78,7 +151,7 @@ export default [
 					rangeType: "tilde",
 				},
 
-				// Require packages that have 0.x.x versions are pinned
+				// Require that packages with 0.x.x versions are pinned
 				{
 					forVersions: "<1",
 					rangeType: "pin",

--- a/docs/rules/restrict-dependency-ranges.md
+++ b/docs/rules/restrict-dependency-ranges.md
@@ -84,7 +84,7 @@ export default [
 			"error",
 			// Restrict typescript to tilde ranges
 			{
-				forPackages: "typescript",
+				forPackages: ["typescript"],
 				rangeType: "tilde",
 			},
 		],
@@ -147,7 +147,7 @@ export default [
 
 				// Restrict typescript to tilde ranges
 				{
-					forPackages: "typescript",
+					forPackages: ["typescript"],
 					rangeType: "tilde",
 				},
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,6 +8,7 @@ import { rule as noRedundantFiles } from "./rules/no-redundant-files.js";
 import { rule as orderProperties } from "./rules/order-properties.js";
 import { rule as preferRepositoryShorthand } from "./rules/repository-shorthand.js";
 import { rules as requireRules } from "./rules/require-properties.js";
+import { rule as restrictDependencyRanges } from "./rules/restrict-dependency-ranges.js";
 import { rule as sortCollections } from "./rules/sort-collections.js";
 import { rule as uniqueDependencies } from "./rules/unique-dependencies.js";
 import { rule as validLocalDependency } from "./rules/valid-local-dependency.js";
@@ -29,6 +30,7 @@ const rules: Record<string, PackageJsonRuleModule> = {
 	"order-properties": orderProperties,
 	...requireRules,
 	"repository-shorthand": preferRepositoryShorthand,
+	"restrict-dependency-ranges": restrictDependencyRanges,
 	"sort-collections": sortCollections,
 	"unique-dependencies": uniqueDependencies,
 	"valid-local-dependency": validLocalDependency,

--- a/src/rules/restrict-dependency-ranges.ts
+++ b/src/rules/restrict-dependency-ranges.ts
@@ -80,9 +80,8 @@ const changeVersionRange = (version: string, rangeType: RangeType): string => {
 			case "pin":
 				return "workspace:*";
 			case "tilde":
-				return "workspace:~";
 			default:
-				return version;
+				return "workspace:~";
 		}
 	}
 

--- a/src/rules/restrict-dependency-ranges.ts
+++ b/src/rules/restrict-dependency-ranges.ts
@@ -174,13 +174,10 @@ export const rule = createRule<Options>({
 							continue;
 						}
 						if (options.forPackages) {
-							let isMatch = false;
-							for (const packageNamePattern of options.forPackages) {
-								if (new RegExp(packageNamePattern).test(name)) {
-									isMatch = true;
-									break;
-								}
-							}
+							const isMatch = options.forPackages.some(
+								(packageNamePattern) =>
+									new RegExp(packageNamePattern).test(name),
+							);
 							if (!isMatch) {
 								continue;
 							}

--- a/src/rules/restrict-dependency-ranges.ts
+++ b/src/rules/restrict-dependency-ranges.ts
@@ -95,12 +95,11 @@ const changeVersionRange = (version: string, rangeType: RangeType): string => {
  * Check if the version is in a form that this rule supports.
  */
 const isVersionSupported = (version: string): boolean => {
-	if (version === "*" || /^workspace:[*^~]$/.test(version)) {
+	if (/^workspace:[*^~]$/.test(version)) {
 		return true;
 	}
-
 	const rawVersion = version.replace(/^workspace:/, "");
-	return !!semver.valid(rawVersion) || !!semver.validRange(rawVersion);
+	return !!semver.validRange(rawVersion);
 };
 
 const capitalize = (str: string): string => {

--- a/src/rules/restrict-dependency-ranges.ts
+++ b/src/rules/restrict-dependency-ranges.ts
@@ -22,8 +22,8 @@ interface Option {
 
 type Options = [Option | Option[] | undefined];
 
-const RANGE_TYPES = ["caret", "pin", "tilde"];
-type RangeType = "caret" | "pin" | "tilde";
+const RANGE_TYPES = ["caret", "pin", "tilde"] as const;
+type RangeType = (typeof RANGE_TYPES)[number];
 
 const schemaOptions = {
 	additionalProperties: false,

--- a/src/rules/restrict-dependency-ranges.ts
+++ b/src/rules/restrict-dependency-ranges.ts
@@ -1,0 +1,294 @@
+import type { AST as JsonAST } from "jsonc-eslint-parser";
+
+import * as ESTree from "estree";
+import semver from "semver";
+
+import { createRule } from "../createRule.js";
+import { isJSONStringLiteral } from "../utils/predicates.js";
+
+const DEPENDENCY_TYPES = [
+	"dependencies",
+	"devDependencies",
+	"optionalDependencies",
+	"peerDependencies",
+];
+
+interface Option {
+	forDependencyTypes?: string[];
+	forPackages?: string[];
+	forVersions?: string;
+	rangeType: RangeType | RangeType[];
+}
+
+type Options = [Option | Option[] | undefined];
+
+const RANGE_TYPES = ["caret", "pin", "tilde"];
+type RangeType = "caret" | "pin" | "tilde";
+
+const schemaOptions = {
+	additionalProperties: false,
+	properties: {
+		forDependencyTypes: {
+			items: {
+				enum: DEPENDENCY_TYPES,
+			},
+			type: "array",
+		},
+		forPackages: {
+			items: {
+				type: "string",
+			},
+			type: "array",
+		},
+		forVersions: {
+			type: "string",
+		},
+		rangeType: {
+			oneOf: [
+				{
+					enum: RANGE_TYPES,
+				},
+				{
+					items: {
+						enum: RANGE_TYPES,
+					},
+					type: "array",
+				},
+			],
+		},
+	},
+	required: ["rangeType"],
+	type: "object",
+};
+
+const SYMBOLS = {
+	caret: "^",
+	pin: "",
+	tilde: "~",
+} satisfies Record<RangeType, string>;
+
+/**
+ * Given the original version, update it to use the correct range type.
+ */
+const changeVersionRange = (version: string, rangeType: RangeType): string => {
+	// We need to handle workspace versions with only the range indicator,
+	// slightly differently
+	if (/^workspace:[~^*]$/.test(version)) {
+		switch (rangeType) {
+			case "caret":
+				return "workspace:^";
+			case "pin":
+				return "workspace:*";
+			case "tilde":
+				return "workspace:~";
+			default:
+				return version;
+		}
+	}
+
+	return version.replace(
+		/^(workspace:)?(\^|~|<=?|>=?)?/,
+		`$1${SYMBOLS[rangeType]}`,
+	);
+};
+
+/**
+ * Check if the version is in a form that this rule supports.
+ */
+const isVersionSupported = (version: string): boolean => {
+	if (version === "*" || /^workspace:[*^~]$/.test(version)) {
+		return true;
+	}
+
+	const rawVersion = version.replace(/^workspace:/, "");
+	return !!semver.valid(rawVersion) || !!semver.validRange(rawVersion);
+};
+
+const capitalize = (str: string): string => {
+	return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+export const rule = createRule<Options>({
+	create(context) {
+		// Bail early if no options were provided
+		if (!context.options[0]) {
+			return {};
+		}
+
+		const optionsArray = Array.isArray(context.options[0])
+			? [...context.options[0]]
+			: [context.options[0]];
+
+		// Reverse the array, so that subsequent options override previous ones
+		optionsArray.reverse();
+
+		return {
+			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.type=JSONLiteral][value.type=JSONObjectExpression]"(
+				node: JsonAST.JSONProperty & {
+					key: JsonAST.JSONStringLiteral;
+					value: JsonAST.JSONObjectExpression;
+				},
+			) {
+				const dependencyType = node.key.value;
+
+				// If this isn't a group of dependencies, skip it entirely
+				if (!DEPENDENCY_TYPES.includes(dependencyType)) {
+					return;
+				}
+
+				// Loop through all dependencies in the group
+				for (const property of node.value.properties) {
+					// If either the key or value aren't strings, this isn't a valid dependency, so move on.
+					if (
+						!isJSONStringLiteral(property.key) ||
+						!isJSONStringLiteral(property.value)
+					) {
+						continue;
+					}
+
+					const name = property.key.value;
+					const version = property.value.value;
+
+					// Check to see if the version is in a format we support
+					if (!isVersionSupported(version)) {
+						continue;
+					}
+
+					const isPinned =
+						!!semver.parse(version) || version === "workspace:*";
+					const isTildeRange =
+						(!!semver.validRange(version) &&
+							version.startsWith("~")) ||
+						version.startsWith("workspace:~");
+					const isCaretRange =
+						(!!semver.validRange(version) &&
+							version.startsWith("^")) ||
+						version.startsWith("workspace:^");
+
+					// Loop through all options, and evaluate each of them for this dependency
+					for (const options of optionsArray) {
+						// Skip these options if they have any conditions that match
+						// the current dependency.
+						if (
+							options.forDependencyTypes &&
+							!options.forDependencyTypes.includes(dependencyType)
+						) {
+							continue;
+						}
+						if (options.forPackages) {
+							let isMatch = false;
+							for (const packageNamePattern of options.forPackages) {
+								if (new RegExp(packageNamePattern).test(name)) {
+									isMatch = true;
+									break;
+								}
+							}
+							if (!isMatch) {
+								continue;
+							}
+						}
+						if (
+							options.forVersions &&
+							// We can't determine whether any workspace version without a numeric version to accompany it, matches this range
+							// so we'll just skip it.
+							(/^workspace:[^~*]?$/.test(version) ||
+								// * matches all
+								(version !== "*" &&
+									!semver.satisfies(
+										version.replace(
+											/(?:workspace:)?[^~]?/,
+											"",
+										),
+										options.forVersions,
+									)))
+						) {
+							continue;
+						}
+
+						// We've matched this set of options, so we should check
+						// the range type.
+						const rangeTypes = Array.isArray(options.rangeType)
+							? options.rangeType
+							: [options.rangeType];
+
+						// If the version is just '*', then this is definitely in violation,
+						// and we can report immediately.
+						if (version === "*") {
+							context.report({
+								data: {
+									rangeTypes: rangeTypes.join(", "),
+								},
+								messageId: "wrongRangeType",
+								node: property.value as unknown as ESTree.Node,
+							});
+							break;
+						}
+
+						const rangeTypeMatch = rangeTypes.find((rangeType) => {
+							switch (rangeType) {
+								case "caret":
+									return isCaretRange;
+								case "pin":
+									return isPinned;
+								case "tilde":
+									return isTildeRange;
+							}
+						});
+
+						// If we didn't match what's in the options, we need to report an error.
+						if (!rangeTypeMatch) {
+							context.report({
+								data: {
+									rangeTypes: rangeTypes.join(", "),
+								},
+								messageId: "wrongRangeType",
+								node: property.value as unknown as ESTree.Node,
+								suggest: rangeTypes.map((rangeType) => ({
+									fix(fixer) {
+										return fixer.replaceText(
+											property.value,
+											`"${changeVersionRange(version, rangeType)}"`,
+										);
+									},
+									messageId: `changeTo${capitalize(rangeType)}`,
+								})),
+							});
+						}
+
+						// Since this option matched the current dependency, and it's the last
+						// one in the array, it takes precedent over any preceding
+						// matching options.  So, no need to process more.
+						break;
+					}
+				}
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			description:
+				"Restricts the range of dependencies to allow or disallow specific types of ranges.",
+		},
+		hasSuggestions: true,
+		messages: {
+			changeToCaret: "Change to use a caret range.",
+			changeToPin: "Pin the version.",
+			changeToTilde: "Change to use a tilde range.",
+			wrongRangeType:
+				"This dependency is using the wrong range type.  Acceptable range type(s): {{rangeTypes}}",
+		},
+		schema: [
+			{
+				oneOf: [
+					schemaOptions,
+					{
+						items: schemaOptions,
+						type: "array",
+					},
+				],
+			},
+		],
+		type: "suggestion",
+	},
+});

--- a/src/tests/rules/restrict-dependency-ranges.test.ts
+++ b/src/tests/rules/restrict-dependency-ranges.test.ts
@@ -14,7 +14,11 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     "${dependencyType}": {
         "abc": "^1.2.3",
         "def": "1.2.3",
-        "ghi": "~1.2.3"
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
     }
 }`,
 			errors: [
@@ -31,7 +35,11 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     "${dependencyType}": {
         "abc": "^1.2.3",
         "def": "^1.2.3",
-        "ghi": "~1.2.3"
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
     }
 }`,
 						},
@@ -50,11 +58,68 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     "${dependencyType}": {
         "abc": "^1.2.3",
         "def": "1.2.3",
-        "ghi": "^1.2.3"
+        "ghi": "^1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
     }
 }`,
 						},
 					],
+				},
+				{
+					data: {
+						rangeTypes: "caret",
+					},
+					line: 6,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToCaret",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3",
+        "jkl": "workspace:^",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
+    }
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "caret",
+					},
+					line: 8,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToCaret",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:^",
+        "stu": "*"
+    }
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "caret",
+					},
+					line: 9,
+					messageId: "wrongRangeType",
 				},
 			],
 			filename: "package.json",
@@ -73,7 +138,11 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     "${dependencyType}": {
         "abc": "^1.2.3",
         "def": "1.2.3",
-        "ghi": "~1.2.3"
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
     }
 }`,
 			errors: [
@@ -90,7 +159,11 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     "${dependencyType}": {
         "abc": "1.2.3",
         "def": "1.2.3",
-        "ghi": "~1.2.3"
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
     }
 }`,
 						},
@@ -109,11 +182,68 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     "${dependencyType}": {
         "abc": "^1.2.3",
         "def": "1.2.3",
-        "ghi": "1.2.3"
+        "ghi": "1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
     }
 }`,
 						},
 					],
+				},
+				{
+					data: {
+						rangeTypes: "pin",
+					},
+					line: 7,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToPin",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:*",
+        "pqr": "workspace:~",
+        "stu": "*"
+    }
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "pin",
+					},
+					line: 8,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToPin",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:*",
+        "stu": "*"
+    }
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "pin",
+					},
+					line: 9,
+					messageId: "wrongRangeType",
 				},
 			],
 			filename: "package.json",
@@ -132,7 +262,11 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     "${dependencyType}": {
         "abc": "^1.2.3",
         "def": "1.2.3",
-        "ghi": "~1.2.3"
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
     }
 }`,
 			errors: [
@@ -149,7 +283,11 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     "${dependencyType}": {
         "abc": "~1.2.3",
         "def": "1.2.3",
-        "ghi": "~1.2.3"
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
     }
 }`,
 						},
@@ -168,11 +306,68 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     "${dependencyType}": {
         "abc": "^1.2.3",
         "def": "~1.2.3",
-        "ghi": "~1.2.3"
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
     }
 }`,
 						},
 					],
+				},
+				{
+					data: {
+						rangeTypes: "tilde",
+					},
+					line: 6,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToTilde",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3",
+        "jkl": "workspace:~",
+        "mno": "workspace:^",
+        "pqr": "workspace:~",
+        "stu": "*"
+    }
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "tilde",
+					},
+					line: 7,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToTilde",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3",
+        "jkl": "workspace:*",
+        "mno": "workspace:~",
+        "pqr": "workspace:~",
+        "stu": "*"
+    }
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "tilde",
+					},
+					line: 9,
+					messageId: "wrongRangeType",
 				},
 			],
 			filename: "package.json",
@@ -239,7 +434,21 @@ ruleTester.run("restrict-dependency-ranges", rule, {
 	],
 
 	valid: [
-		{ code: "{}", name: "empty package.json" },
+		{
+			code: `{
+	"dependencies": {
+		"abc": "^1.2.3",
+        "def": "workspace:~1.2.3",
+        "ghi": "workspace:*"
+	}
+}`,
+			name: "no options",
+		},
+		{
+			code: "{}",
+			name: "empty package.json",
+			options: [{ rangeType: "caret" }],
+		},
 		{
 			code: `{
     "dependencies": {
@@ -250,6 +459,32 @@ ruleTester.run("restrict-dependency-ranges", rule, {
     }
 }`,
 			name: "ignored version formats",
+			options: [{ rangeType: "caret" }],
+		},
+		{
+			code: `{
+    "bin": {
+        "abc": "bin/abc.js"
+    }
+}`,
+			name: "no dependencies",
+			options: [{ rangeType: "caret" }],
+		},
+		{
+			code: `{
+    "dependencies": {
+        "abc": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/abc/-/abc-1.2.3.tgz",
+            "integrity": "sha512-abc"
+        },
+        "def": 123,
+        "ghi": true,
+        "jkl": null
+    }
+}`,
+			name: "malformed dependencies",
+			options: [{ rangeType: "caret" }],
 		},
 
 		// rangeType: 'caret'

--- a/src/tests/rules/restrict-dependency-ranges.test.ts
+++ b/src/tests/rules/restrict-dependency-ranges.test.ts
@@ -1,0 +1,503 @@
+import { rule } from "../../rules/restrict-dependency-ranges.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("restrict-dependency-ranges", rule, {
+	invalid: [
+		// rangeType: 'caret'
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3"
+    }
+}`,
+			errors: [
+				{
+					data: {
+						rangeTypes: "caret",
+					},
+					line: 4,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToCaret",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "^1.2.3",
+        "ghi": "~1.2.3"
+    }
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "caret",
+					},
+					line: 5,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToCaret",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "^1.2.3"
+    }
+}`,
+						},
+					],
+				},
+			],
+			filename: "package.json",
+			name: `rangeType: 'caret'; dependencyType: '${dependencyType}'`,
+			options: [{ rangeType: "caret" }],
+		})),
+
+		// rangeType: 'pin'
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3"
+    }
+}`,
+			errors: [
+				{
+					data: {
+						rangeTypes: "pin",
+					},
+					line: 3,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToPin",
+							output: `{
+    "${dependencyType}": {
+        "abc": "1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3"
+    }
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "pin",
+					},
+					line: 5,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToPin",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "1.2.3"
+    }
+}`,
+						},
+					],
+				},
+			],
+			filename: "package.json",
+			name: `rangeType: 'pin'; dependencyType: '${dependencyType}'`,
+			options: [{ rangeType: "pin" }],
+		})),
+
+		// rangeType: 'tilde'
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3"
+    }
+}`,
+			errors: [
+				{
+					data: {
+						rangeTypes: "tilde",
+					},
+					line: 3,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToTilde",
+							output: `{
+    "${dependencyType}": {
+        "abc": "~1.2.3",
+        "def": "1.2.3",
+        "ghi": "~1.2.3"
+    }
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "tilde",
+					},
+					line: 4,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToTilde",
+							output: `{
+    "${dependencyType}": {
+        "abc": "^1.2.3",
+        "def": "~1.2.3",
+        "ghi": "~1.2.3"
+    }
+}`,
+						},
+					],
+				},
+			],
+			filename: "package.json",
+			name: `rangeType: 'tilde'; dependencyType: '${dependencyType}'`,
+			options: [{ rangeType: "tilde" }],
+		})),
+
+		// multiple options (last wins)
+		{
+			code: `{
+	"dependencies": {
+		"abc": "~1.2.3",
+        "def": "workspace:~1.2.3",
+        "ghi": "workspace:*",
+        "jkl": "1.2.3"
+	}
+}`,
+			errors: [
+				{
+					data: {
+						rangeTypes: "tilde",
+					},
+					line: 5,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToTilde",
+							output: `{
+	"dependencies": {
+		"abc": "~1.2.3",
+        "def": "workspace:~1.2.3",
+        "ghi": "workspace:~",
+        "jkl": "1.2.3"
+	}
+}`,
+						},
+					],
+				},
+				{
+					data: {
+						rangeTypes: "tilde",
+					},
+					line: 6,
+					messageId: "wrongRangeType",
+					suggestions: [
+						{
+							messageId: "changeToTilde",
+							output: `{
+	"dependencies": {
+		"abc": "~1.2.3",
+        "def": "workspace:~1.2.3",
+        "ghi": "workspace:*",
+        "jkl": "~1.2.3"
+	}
+}`,
+						},
+					],
+				},
+			],
+			filename: "package.json",
+			name: `[{ rangeType: 'pin' }, { rangeType: 'tilde' }]`,
+			options: [[{ rangeType: "pin" }, { rangeType: "tilde" }]],
+		},
+	],
+
+	valid: [
+		{ code: "{}", name: "empty package.json" },
+		{
+			code: `{
+    "dependencies": {
+        "abc": "catalog:",
+        "def": "user/repo",
+        "ghi": "file:../foo/bar",
+        "jkl": "git+https://user@github.com/user/repo.git"
+    }
+}`,
+			name: "ignored version formats",
+		},
+
+		// rangeType: 'caret'
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {}
+}`,
+			name: `rangeType: 'caret'; dependencyType: '${dependencyType}'; no deps`,
+			options: [{ rangeType: "caret" }],
+		})),
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {
+		"abc": "^1.2.3",
+        "def": "workspace:^1.2.3",
+        "ghi": "workspace:^"
+	}
+}`,
+			name: `rangeType: 'caret'; dependencyType: '${dependencyType}'`,
+			options: [{ rangeType: "caret" }],
+		})),
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {
+		"abc": "^1.2.3",
+        "def": "workspace:^1.2.3",
+        "ghi": "workspace:^"
+	}
+}`,
+			name: `rangeType: ['caret']; dependencyType: '${dependencyType}'`,
+			options: [[{ rangeType: ["caret"] }]],
+		})),
+
+		// rangeType: 'pin'
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {}
+}`,
+			name: `rangeType: 'pin'; dependencyType: '${dependencyType}'; no deps`,
+			options: [{ rangeType: "pin" }],
+		})),
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {
+		"abc": "1.2.3",
+        "def": "workspace:*"
+	}
+}`,
+			name: `rangeType: 'pin'; dependencyType: '${dependencyType}'`,
+			options: [{ rangeType: "pin" }],
+		})),
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {
+		"abc": "1.2.3",
+        "def": "workspace:*"
+	}
+}`,
+			name: `rangeType: ['pin']; dependencyType: '${dependencyType}'`,
+			options: [[{ rangeType: ["pin"] }]],
+		})),
+
+		// rangeType: 'tilde'
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {}
+}`,
+			name: `rangeType: 'tilde'; dependencyType: '${dependencyType}'; no deps`,
+			options: [{ rangeType: "tilde" }],
+		})),
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {
+		"abc": "~1.2.3",
+        "def": "workspace:~1.2.3",
+        "ghi": "workspace:~"
+	}
+}`,
+			name: `rangeType: 'tilde'; dependencyType: '${dependencyType}'`,
+			options: [{ rangeType: "tilde" }],
+		})),
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {
+		"abc": "~1.2.3",
+        "def": "workspace:~1.2.3",
+        "ghi": "workspace:~"
+	}
+}`,
+			name: `rangeType: ['tilde']; dependencyType: '${dependencyType}'`,
+			options: [[{ rangeType: ["tilde"] }]],
+		})),
+
+		// rangeType: 'pin' and 'tilde'
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {
+		"abc": "~1.2.3",
+        "def": "workspace:~1.2.3",
+        "ghi": "workspace:~",
+        "jkl": "1.2.3",
+        "mno": "workspace:*"
+	}
+}`,
+			name: `rangeType: ['pin', 'tilde']; dependencyType: '${dependencyType}'`,
+			options: [[{ rangeType: ["pin", "tilde"] }]],
+		})),
+
+		// forDependencyTypes: devDependencies
+		{
+			code: `{
+    "dependencies": {
+		"abc": "~1.2.3",
+        "def": "workspace:1.2.3",
+        "ghi": "workspace:*"
+	},
+	"devDependencies": {
+		"abc": "^1.2.3",
+        "def": "workspace:^1.2.3",
+        "ghi": "workspace:^"
+	}
+}`,
+			name: "forDependencyTypes: 'devDependencies'",
+			options: [
+				{ forDependencyTypes: ["devDependencies"], rangeType: "caret" },
+			],
+		},
+
+		// forPackages: abc
+		{
+			code: `{
+    "dependencies": {
+		"abc": "~1.2.3",
+        "def": "workspace:1.2.3",
+        "ghi": "workspace:*"
+	},
+	"devDependencies": {
+		"abc": "~1.2.3",
+        "def": "workspace:^1.2.3",
+        "ghi": "workspace:^"
+	}
+}`,
+			name: "forPackages: 'abc'",
+			options: [{ forPackages: ["abc"], rangeType: "tilde" }],
+		},
+
+		// forPackages: ^a.+
+		{
+			code: `{
+    "dependencies": {
+		"abc": "~1.2.3",
+        "def": "workspace:1.2.3",
+        "ghi": "workspace:*"
+	},
+	"devDependencies": {
+		"abc": "~1.2.3",
+        "def": "workspace:^1.2.3",
+        "ghi": "workspace:^"
+	}
+}`,
+			name: "forPackages: '^a.+'",
+			options: [{ forPackages: ["^a.+"], rangeType: "tilde" }],
+		},
+
+		// forVersions: <1
+		{
+			code: `{
+    "dependencies": {
+		"abc": "~1.2.3",
+        "def": "0.1.2",
+        "ghi": "workspace:^"
+	},
+	"devDependencies": {
+		"abc": "1.2.3",
+        "def": "0.1.2",
+        "ghi": "workspace:^"
+	}
+}`,
+			name: "forVersions: '<1'",
+			options: [{ forVersions: "<1", rangeType: "pin" }],
+		},
+
+		// multiple options (last one wins)
+		...[
+			"dependencies",
+			"devDependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		].map((dependencyType) => ({
+			code: `{
+	"${dependencyType}": {
+		"abc": "~1.2.3",
+        "def": "workspace:~1.2.3",
+        "ghi": "workspace:~",
+	}
+}`,
+			name: `[{ rangeType: "pin" }, { rangeType: "tilde" }]; dependencyType: '${dependencyType}'`,
+			options: [[{ rangeType: "pin" }, { rangeType: "tilde" }]],
+		})),
+	],
+});

--- a/src/tests/rules/restrict-dependency-ranges.test.ts
+++ b/src/tests/rules/restrict-dependency-ranges.test.ts
@@ -480,7 +480,8 @@ ruleTester.run("restrict-dependency-ranges", rule, {
         },
         "def": 123,
         "ghi": true,
-        "jkl": null
+        "jkl": null,
+        123: "~1.2.3",
     }
 }`,
 			name: "malformed dependencies",

--- a/src/tests/rules/restrict-dependency-ranges.test.ts
+++ b/src/tests/rules/restrict-dependency-ranges.test.ts
@@ -463,8 +463,8 @@ ruleTester.run("restrict-dependency-ranges", rule, {
 		},
 		{
 			code: `{
-    "bin": {
-        "abc": "bin/abc.js"
+    "notDependencies": {
+        "abc": "*"
     }
 }`,
 			name: "no dependencies",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #959
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new rule that allows you to restrict usage of semver ranges on dependencies using any of the following matching options:
- by dependency name or regex pattern
- by version
- by dependency type

Closes #959 