### PR TITLE
feat(sort-collections): add custom sort order option

### DIFF
--- a/site/src/content/docs/rules/sort-collections.mdx
+++ b/site/src/content/docs/rules/sort-collections.mdx
@@ -141,9 +141,23 @@ Incorrect vs. correct ordering of a complete lifecycle group:
 
 ## Options
 
+{/* begin auto-generated rule options list */}
+
+| Name    | Description                                                                                 | Type     | Required |
+| :------ | :------------------------------------------------------------------------------------------ | :------- | :------- |
+| `key`   | The collection property to sort.                                                            | String   | Yes      |
+| `order` | The order to sort the collection by. Keys not listed are appended in lexicographical order. | String[] | Yes      |
+
+{/* end auto-generated rule options list */}
+
 Pass an array of package properties to require sorting on those collections.
 To specify a nested property, use dot notation.
 All of their values must be objects.
+
+Each entry is either:
+
+- A string: the collection to sort the default way (lexicographically, or lifecycle-aware for `scripts`)
+- An object (`{ key: string; order: string[] }`): sort the collection named by `key` using the given `order`; keys not listed in `order` are appended afterwards, sorted lexicographically
 
 Example of only sorting `devDependencies` and `pnpm.patchedDependencies`:
 
@@ -152,6 +166,17 @@ Example of only sorting `devDependencies` and `pnpm.patchedDependencies`:
   "package-json/sort-collections": [
     "error",
     ["devDependencies", "pnpm.patchedDependencies"]
+  ]
+}
+```
+
+Example of enforcing a custom order for `nx` while still sorting `dependencies` the default way:
+
+```json
+{
+  "package-json/sort-collections": [
+    "error",
+    ["dependencies", { "key": "nx", "order": ["npmScope", "affected"] }]
   ]
 }
 ```

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -59,50 +59,45 @@ export const rule = createRule({
         }
 
         const currentOrder = collection.properties;
-        let desiredOrder: JsonAST.JSONProperty[];
 
         const isScripts = keyPartsReversed.at(-1) === 'scripts';
 
-        if (isScripts && !customOrder) {
-          // For scripts we'll use `sort-package-json`
+        // The "natural" order for keys not pinned by a custom order: `scripts`
+        // are lifecycle-aware (via `sort-package-json`), everything else is
+        // lexicographical.
+        let naturalCompare: (a: string, b: string) => number;
+        if (isScripts) {
           const scriptsSource = context.sourceCode.getText(node);
           const minimalJson = JSON.parse(`{${scriptsSource}}`) as {
             scripts: Record<string, unknown>;
           };
           const { scripts: sortedScripts } = sortPackageJson(minimalJson);
-
-          const propertyNodeMap = Object.fromEntries(
-            collection.properties.map((prop) => [
-              (prop.key as JsonAST.JSONStringLiteral).value,
-              prop,
-            ]),
+          const lifecycleIndex = new Map(
+            Object.keys(sortedScripts).map((k, i) => [k, i]),
           );
-
-          // Used the scripts object sorted by `sort-package-json` to create the desiredOrder
-          desiredOrder = Object.keys(sortedScripts).map(
-            (prop) => propertyNodeMap[prop],
-          );
-
-          // Otherwise sort by the custom order (if any); keys not listed in it
-          // (or every key, when no custom order is given) are appended in
-          // lexicographical order.
+          naturalCompare = (a, b) =>
+            (lifecycleIndex.get(a) ?? 0) - (lifecycleIndex.get(b) ?? 0);
         } else {
-          const orderIndex = new Map((customOrder ?? []).map((k, i) => [k, i]));
-          const rank = (k: string) => orderIndex.get(k) ?? orderIndex.size;
-
-          desiredOrder = currentOrder.toSorted((a, b) => {
-            const aKey = (a.key as JsonAST.JSONStringLiteral).value;
-            const bKey = (b.key as JsonAST.JSONStringLiteral).value;
-            const ai = rank(aKey);
-            const bi = rank(bKey);
-
-            if (ai !== bi) {
-              return ai - bi;
-            }
-
-            return aKey > bKey ? 1 : -1;
-          });
+          naturalCompare = (a, b) => (a > b ? 1 : -1);
         }
+
+        // Custom order (if any) takes precedence; keys not listed in it fall
+        // back to the natural order above (lifecycle-aware for `scripts`).
+        const orderIndex = new Map((customOrder ?? []).map((k, i) => [k, i]));
+        const rank = (k: string) => orderIndex.get(k) ?? orderIndex.size;
+
+        const desiredOrder = currentOrder.toSorted((a, b) => {
+          const aKey = (a.key as JsonAST.JSONStringLiteral).value;
+          const bKey = (b.key as JsonAST.JSONStringLiteral).value;
+          const ai = rank(aKey);
+          const bi = rank(bKey);
+
+          if (ai !== bi) {
+            return ai - bi;
+          }
+
+          return naturalCompare(aKey, bKey);
+        });
 
         if (currentOrder.some((property, i) => desiredOrder[i] !== property)) {
           context.report({
@@ -178,6 +173,7 @@ export const rule = createRule({
                     type: 'string',
                   },
                   type: 'array',
+                  uniqueItems: true,
                 },
               },
               required: ['key', 'order'],

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -17,9 +17,11 @@ const defaultCollections = new Set([
 
 export const rule = createRule({
   create(context) {
-    const toSort = context.options[0]
-      ? new Set(context.options[0])
-      : defaultCollections;
+    const toSort = new Map<string, null | string[]>(
+      (context.options[0] ?? Array.from(defaultCollections)).map((entry) =>
+        typeof entry === 'string' ? [entry, null] : [entry.key, entry.order],
+      ),
+    );
 
     return {
       'JSONProperty:exit'(node) {
@@ -49,14 +51,19 @@ export const rule = createRule({
           }
         }
         const key = keyPartsReversed.reverse().join('.');
-        if (!toSort.has(key)) {
+        // `undefined` means the key isn't configured for sorting; `null` means
+        // sort it the default way; an array is a custom order.
+        const customOrder = toSort.get(key);
+        if (customOrder === undefined) {
           return;
         }
 
         const currentOrder = collection.properties;
         let desiredOrder: JsonAST.JSONProperty[];
 
-        if (keyPartsReversed.at(-1) === 'scripts') {
+        const isScripts = keyPartsReversed.at(-1) === 'scripts';
+
+        if (isScripts && !customOrder) {
           // For scripts we'll use `sort-package-json`
           const scriptsSource = context.sourceCode.getText(node);
           const minimalJson = JSON.parse(`{${scriptsSource}}`) as {
@@ -76,11 +83,22 @@ export const rule = createRule({
             (prop) => propertyNodeMap[prop],
           );
 
-          // If it's any property other than `scripts`, simply sort lexicographically
+          // Otherwise sort by the custom order (if any); keys not listed in it
+          // (or every key, when no custom order is given) are appended in
+          // lexicographical order.
         } else {
+          const orderIndex = new Map((customOrder ?? []).map((k, i) => [k, i]));
+          const rank = (k: string) => orderIndex.get(k) ?? orderIndex.size;
+
           desiredOrder = currentOrder.toSorted((a, b) => {
             const aKey = (a.key as JsonAST.JSONStringLiteral).value;
             const bKey = (b.key as JsonAST.JSONStringLiteral).value;
+            const ai = rank(aKey);
+            const bi = rank(bKey);
+
+            if (ai !== bi) {
+              return ai - bi;
+            }
 
             return aKey > bKey ? 1 : -1;
           });
@@ -111,8 +129,9 @@ export const rule = createRule({
               );
             },
             loc: collection.loc,
-            messageId:
-              keyPartsReversed.at(-1) === 'scripts'
+            messageId: customOrder
+              ? 'unsortedOrder'
+              : isScripts
                 ? 'unsortedScripts'
                 : 'unsortedKeys',
             node,
@@ -132,14 +151,39 @@ export const rule = createRule({
     fixable: 'code',
     messages: {
       unsortedKeys: "Entries in '{{ key }}' are not in lexicographical order",
+      unsortedOrder: "Entries in '{{ key }}' are not in the specified order",
       unsortedScripts:
         "Entries in 'scripts' are not in lexicographical order and grouped by lifecycles",
     },
     schema: [
       {
-        description: 'Array of package properties to require sorting.',
+        description:
+          'Array of package properties to require sorting. Provide a string to sort that collection lexicographically (lifecycle-aware for `scripts`), or an object to sort it by a specified order.',
         items: {
-          type: 'string',
+          anyOf: [
+            {
+              type: 'string',
+            },
+            {
+              additionalProperties: false,
+              properties: {
+                key: {
+                  description: 'The collection property to sort.',
+                  type: 'string',
+                },
+                order: {
+                  description:
+                    'The order to sort the collection by. Keys not listed are appended in lexicographical order.',
+                  items: {
+                    type: 'string',
+                  },
+                  type: 'array',
+                },
+              },
+              required: ['key', 'order'],
+              type: 'object',
+            },
+          ],
         },
         type: 'array',
       },

--- a/src/tests/rules/sort-collections.test.ts
+++ b/src/tests/rules/sort-collections.test.ts
@@ -222,6 +222,54 @@ ruleTester.run('sort-collections', rule, {
 	}
 }`,
     },
+    // custom order: listed keys follow the specified order
+    {
+      code: `{
+	"nx": {
+		"affected": {},
+		"npmScope": "test"
+	}
+}`,
+      errors: [
+        {
+          data: { key: 'nx' },
+          messageId: 'unsortedOrder',
+        },
+      ],
+      filename: 'package.json',
+      options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
+      output: `{
+	"nx": {
+    "npmScope": "test",
+    "affected": {}
+  }
+}`,
+    },
+    // custom order: unlisted keys appended in lexicographical order
+    {
+      code: `{
+	"nx": {
+		"workspaceLayout": {},
+		"affected": {},
+		"npmScope": "test"
+	}
+}`,
+      errors: [
+        {
+          data: { key: 'nx' },
+          messageId: 'unsortedOrder',
+        },
+      ],
+      filename: 'package.json',
+      options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
+      output: `{
+	"nx": {
+    "npmScope": "test",
+    "affected": {},
+    "workspaceLayout": {}
+  }
+}`,
+    },
   ],
 
   valid: [
@@ -364,6 +412,46 @@ ruleTester.run('sort-collections', rule, {
   ]
 }`,
       options: [['foo.0.bar']],
+    },
+    // custom order: already in the specified order
+    {
+      code: `{
+	"nx": {
+		"npmScope": "test",
+		"affected": {}
+	}
+}`,
+      filename: 'package.json',
+      options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
+    },
+    // custom order: unlisted keys already appended lexicographically
+    {
+      code: `{
+	"nx": {
+		"npmScope": "test",
+		"affected": {},
+		"workspaceLayout": {}
+	}
+}`,
+      filename: 'package.json',
+      options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
+    },
+    // mixed array: string entries and object entries coexist
+    {
+      code: `{
+	"devDependencies": {
+		"a": "1",
+		"b": "2"
+	},
+	"nx": {
+		"npmScope": "test",
+		"affected": {}
+	}
+}`,
+      filename: 'package.json',
+      options: [
+        ['devDependencies', { key: 'nx', order: ['npmScope', 'affected'] }],
+      ],
     },
   ],
 });

--- a/src/tests/rules/sort-collections.test.ts
+++ b/src/tests/rules/sort-collections.test.ts
@@ -270,6 +270,35 @@ ruleTester.run('sort-collections', rule, {
   }
 }`,
     },
+    // custom order on `scripts`: listed keys come first, unlisted keys fall
+    // back to lifecycle-aware order (not lexicographical)
+    {
+      code: `{
+	"scripts": {
+		"build": "echo build",
+		"prebuild": "echo prebuild",
+		"postbuild": "echo postbuild",
+		"watch": "echo watch"
+	}
+}`,
+      errors: [
+        {
+          data: { key: 'scripts' },
+          messageId: 'unsortedOrder',
+        },
+      ],
+      filename: 'package.json',
+      name: 'custom order on scripts keeps unlisted keys lifecycle-aware',
+      options: [[{ key: 'scripts', order: ['watch'] }]],
+      output: `{
+	"scripts": {
+    "watch": "echo watch",
+    "prebuild": "echo prebuild",
+    "build": "echo build",
+    "postbuild": "echo postbuild"
+  }
+}`,
+    },
   ],
 
   valid: [
@@ -452,6 +481,21 @@ ruleTester.run('sort-collections', rule, {
       options: [
         ['devDependencies', { key: 'nx', order: ['npmScope', 'affected'] }],
       ],
+    },
+    // custom order on `scripts`: listed key first, unlisted keys already in
+    // lifecycle-aware order
+    {
+      code: `{
+	"scripts": {
+		"watch": "echo watch",
+		"prebuild": "echo prebuild",
+		"build": "echo build",
+		"postbuild": "echo postbuild"
+	}
+}`,
+      filename: 'package.json',
+      name: 'custom order on scripts with unlisted keys already lifecycle-sorted',
+      options: [[{ key: 'scripts', order: ['watch'] }]],
     },
   ],
 });

--- a/src/tests/rules/sort-collections.test.ts
+++ b/src/tests/rules/sort-collections.test.ts
@@ -237,6 +237,7 @@ ruleTester.run('sort-collections', rule, {
         },
       ],
       filename: 'package.json',
+      name: 'custom order: listed keys follow the specified order',
       options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
       output: `{
 	"nx": {
@@ -261,6 +262,7 @@ ruleTester.run('sort-collections', rule, {
         },
       ],
       filename: 'package.json',
+      name: 'custom order: unlisted keys appended in lexicographical order',
       options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
       output: `{
 	"nx": {
@@ -451,6 +453,7 @@ ruleTester.run('sort-collections', rule, {
 	}
 }`,
       filename: 'package.json',
+      name: 'custom order: already in the specified order',
       options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
     },
     // custom order: unlisted keys already appended lexicographically
@@ -463,6 +466,7 @@ ruleTester.run('sort-collections', rule, {
 	}
 }`,
       filename: 'package.json',
+      name: 'custom order: unlisted keys already appended lexicographically',
       options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
     },
     // mixed array: string entries and object entries coexist
@@ -478,6 +482,7 @@ ruleTester.run('sort-collections', rule, {
 	}
 }`,
       filename: 'package.json',
+      name: 'mixed array: string entries and object entries coexist',
       options: [
         ['devDependencies', { key: 'nx', order: ['npmScope', 'affected'] }],
       ],


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1390
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Allow an option entry to be an object `{ key, order }` so a collection can be sorted by a specified reference order (e.g. nx schema) instead of lexicographically. Keys present in the collection but not listed in order are appended after the listed keys, sorted lexicographically among themselves. Collections not named in the options are left untouched (unchanged).
