### PR TITLE
feat(scripts-name-casing): add options for ignoring scripts

### DIFF
--- a/site/src/content/docs/rules/scripts-name-casing.mdx
+++ b/site/src/content/docs/rules/scripts-name-casing.mdx
@@ -43,6 +43,47 @@ It also permits kebab case segments separated by colons (e.g. `"test:my-script"`
 </TabItem>
 </Tabs>
 
+## Options
+
+{/* begin auto-generated rule options list */}
+
+| Name             | Description                                | Type  |
+| :--------------- | :----------------------------------------- | :---- |
+| `ignoreNames`    | Specific script names to ignore.           | Array |
+| `ignorePatterns` | Regex patterns for script names to ignore. | Array |
+
+{/* end auto-generated rule options list */}
+
+### `ignoreNames`
+
+Define an array of specific script names that should be ignored by this rule.
+
+```json
+{
+  "scripts-name-casing": [
+    "error",
+    {
+      "ignoreNames": ["myCustomScript", "anotherScript"]
+    }
+  ]
+}
+```
+
+### `ignorePatterns`
+
+Define an array of regex patterns that should be ignored by this rule.
+
+```json
+{
+  "scripts-name-casing": [
+    "error",
+    {
+      "ignorePatterns": ["^myCustom.*", ".*Script$"]
+    }
+  ]
+}
+```
+
 ## Related Rules
 
 - [`require-scripts`](/rules/require-properties/require-scripts) - Enforces that the `scripts` property is present.

--- a/src/rules/scripts-name-casing.ts
+++ b/src/rules/scripts-name-casing.ts
@@ -3,14 +3,22 @@ import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 
-// See https://docs.npmjs.com/cli/v11/using-npm/scripts
 const BUILT_IN_SCRIPTS_IN_CAMEL_CASE = new Set([
+  // See https://docs.npmjs.com/cli/v11/using-npm/scripts
   'prepublishOnly',
+  // https://pnpm.io/scripts#pnpmdevpreinstall
   'pnpm:devPreinstall',
 ]);
 
 export const rule = createRule({
   create(context) {
+    const { ignoreNames = [], ignorePatterns = [] } = context.options[0] ?? {};
+    const ignoreRegexes = ignorePatterns.map((pattern) => new RegExp(pattern));
+
+    const isIgnored = (name: string) =>
+      ignoreNames.includes(name) ||
+      ignoreRegexes.some((regex) => regex.test(name));
+
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=scripts]'(
         node: AST.JSONProperty,
@@ -19,7 +27,7 @@ export const rule = createRule({
           for (const property of node.value.properties) {
             const keyNode = property.key as AST.JSONStringLiteral;
             const key = keyNode.value;
-            if (BUILT_IN_SCRIPTS_IN_CAMEL_CASE.has(key)) {
+            if (BUILT_IN_SCRIPTS_IN_CAMEL_CASE.has(key) || isIgnored(key)) {
               continue;
             }
 
@@ -61,6 +69,7 @@ export const rule = createRule({
     };
   },
   meta: {
+    defaultOptions: [{}],
     docs: {
       category: 'Stylistic',
       description:
@@ -71,7 +80,28 @@ export const rule = createRule({
       convertToKebabCase: 'Convert {{ property }} to kebab case.',
       invalidCase: 'Script name {{ property }} should be in kebab case.',
     },
-    schema: [],
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          ignoreNames: {
+            items: {
+              type: ['string'],
+            },
+            type: ['array'],
+            description: 'Specific script names to ignore.',
+          },
+          ignorePatterns: {
+            items: {
+              type: ['string'],
+            },
+            type: ['array'],
+            description: 'Regex patterns for script names to ignore.',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
   name: 'scripts-name-casing',

--- a/src/tests/rules/scripts-name-casing.test.ts
+++ b/src/tests/rules/scripts-name-casing.test.ts
@@ -122,5 +122,21 @@ ruleTester.run('scripts-name-casing', rule, {
     `{ "scripts": { "prepublishOnly": "npm run build" } }`,
     `{ "scripts": { "pnpm:devPreinstall": "node preinstall.mjs" } }`,
     `{ "scripts": { ".silver-mt-zion": "silver-mt-zion.js", "nin": "./nin.js" } }`,
+    {
+      code: `{ "scripts": { "SilverMtZion": "silver-mt-zion.js", "nin": "./nin.js" } }`,
+      options: [
+        {
+          ignoreNames: ['SilverMtZion'],
+        },
+      ],
+    },
+    {
+      code: `{ "scripts": { "~silver-mt-zion": "silver-mt-zion.js", "nin": "./nin.js" } }`,
+      options: [
+        {
+          ignorePatterns: ['^~.*'],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2050
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change introduces two new options for `scripts-name-casing`:
- `ignoreNames`: allows you to configure specific script names for the rule to ignore
- `ignorePatterns`: allows you to specify regex patterns to ignore

