### PR TITLE
fix(valid-dependencies): package manager detection should support ranges

### DIFF
--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -55,7 +55,14 @@ const packageManagerAwareValidateDependencies: ValidationFunction = (value) => {
   if (result?.name === 'pnpm') {
     const version = result.version;
 
-    if (!version || semver.gte(version, '11.1.0')) {
+    const isValidSemver = !!semver.valid(version);
+    const isValidRange = !!semver.validRange(version);
+
+    if (
+      !version ||
+      (isValidSemver && semver.gte(version, '11.1.0')) ||
+      (isValidRange && semver.satisfies('11.1.0', version))
+    ) {
       return validateDependencies(value, { allowNamedRegistries: true });
     }
   }

--- a/src/tests/rules/valid-dependencies.test.ts
+++ b/src/tests/rules/valid-dependencies.test.ts
@@ -68,6 +68,56 @@ const testEnvironments: TestEnvironment[] = [
     ],
   },
   {
+    description: 'with pnpm 11.x',
+    before: () => {
+      vi.mocked(detectPackageManager).mockReturnValue({
+        name: 'pnpm',
+        version: '11.x',
+      });
+    },
+    additionalValidTests: [
+      {
+        code: `{
+  "dependencies": {
+    "cst-records": "record-label:foo@^1.2.3"
+  }
+}
+`,
+      },
+    ],
+    additionalInvalidTests: [
+      {
+        code: `{
+  "dependencies": {
+    "empty-custom-protocol": "work:",
+    "bad-custom-protocol": "work:git+foo://github.com/npm/cli.git"
+  }
+}
+`,
+        errors: [
+          {
+            column: 30,
+            data: {
+              error:
+                'invalid version spec for dependency `empty-custom-protocol`: Unsupported URL Type "work:": work:',
+            },
+            line: 3,
+            messageId: 'validationError',
+          },
+          {
+            column: 28,
+            data: {
+              error:
+                'invalid custom protocol arg for dependency `bad-custom-protocol`: Unsupported URL Type "git+foo:": git+foo://github.com/npm/cli.git',
+            },
+            line: 4,
+            messageId: 'validationError',
+          },
+        ],
+      },
+    ],
+  },
+  {
     description: 'with pnpm 11.0.0',
     before: () => {
       vi.mocked(detectPackageManager).mockReturnValue({

--- a/src/tests/rules/valid-dependencies.test.ts
+++ b/src/tests/rules/valid-dependencies.test.ts
@@ -118,6 +118,56 @@ const testEnvironments: TestEnvironment[] = [
     ],
   },
   {
+    description: 'with pnpm 11',
+    before: () => {
+      vi.mocked(detectPackageManager).mockReturnValue({
+        name: 'pnpm',
+        version: '11',
+      });
+    },
+    additionalValidTests: [
+      {
+        code: `{
+  "dependencies": {
+    "cst-records": "record-label:foo@^1.2.3"
+  }
+}
+`,
+      },
+    ],
+    additionalInvalidTests: [
+      {
+        code: `{
+  "dependencies": {
+    "empty-custom-protocol": "work:",
+    "bad-custom-protocol": "work:git+foo://github.com/npm/cli.git"
+  }
+}
+`,
+        errors: [
+          {
+            column: 30,
+            data: {
+              error:
+                'invalid version spec for dependency `empty-custom-protocol`: Unsupported URL Type "work:": work:',
+            },
+            line: 3,
+            messageId: 'validationError',
+          },
+          {
+            column: 28,
+            data: {
+              error:
+                'invalid custom protocol arg for dependency `bad-custom-protocol`: Unsupported URL Type "git+foo:": git+foo://github.com/npm/cli.git',
+            },
+            line: 4,
+            messageId: 'validationError',
+          },
+        ],
+      },
+    ],
+  },
+  {
     description: 'with pnpm 11.0.0',
     before: () => {
       vi.mocked(detectPackageManager).mockReturnValue({


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2091
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The original implementation of the package detection logic recently added to `valid-dependencies` to determine if we should relax protocol validation was assuming that `detectPackageManager` would always return a valid semver.  That will be the case if `packageManager` is used, but when `devEngines.packageManager.version` is used, ranges are valid, and this logic broke.

Now we're testing that the detected version is greater than 11.1.0 OR 11.1.0 is included in the detected range.