### PR TITLE
fix: do not rewrite null exports in `exports-subpaths-style`

### DIFF
--- a/src/rules/exports-subpaths-style.ts
+++ b/src/rules/exports-subpaths-style.ts
@@ -1,7 +1,10 @@
 import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
-import { isJSONStringLiteral } from '../utils/predicates/index.ts';
+import {
+  isJSONNullLiteral,
+  isJSONStringLiteral,
+} from '../utils/predicates/index.ts';
 
 function isImplicitFormat(
   node: AST.JSONLiteral | AST.JSONObjectExpression,
@@ -24,6 +27,14 @@ export const rule = createRule({
 
     function validateForExplicit(node: AST.JSONProperty) {
       const { value } = node;
+
+      // A top-level null is not a root export; Node treats it as if the
+      // exports field were absent (legacy resolution). Wrapping it would
+      // enable encapsulation and change runtime behavior.
+      if (isJSONNullLiteral(value)) {
+        return;
+      }
+
       if (
         (value.type !== 'JSONLiteral' &&
           value.type !== 'JSONObjectExpression') ||
@@ -64,6 +75,13 @@ export const rule = createRule({
       }
 
       const dotProperty = value.properties[0];
+
+      // A null target means "not exported". Rewriting `{ ".": null }` to
+      // `null` removes encapsulation and restores legacy resolution.
+      if (isJSONNullLiteral(dotProperty.value)) {
+        return;
+      }
+
       context.report({
         fix(fixer) {
           const valueText = context.sourceCode.getText(dotProperty.value);

--- a/src/tests/rules/exports-subpaths-style.test.ts
+++ b/src/tests/rules/exports-subpaths-style.test.ts
@@ -44,13 +44,6 @@ ruleTester.run('exports-subpaths-style', rule, {
   ".": true
 } }`,
     },
-    {
-      code: `{ "exports": null }`,
-      errors: [{ messageId: 'preferExplicit' }],
-      output: `{ "exports": {
-  ".": null
-} }`,
-    },
     // With explicit option
     {
       code: `{ "exports": "./index.js" }`,

--- a/src/tests/rules/exports-subpaths-style.test.ts
+++ b/src/tests/rules/exports-subpaths-style.test.ts
@@ -206,5 +206,25 @@ ruleTester.run('exports-subpaths-style', rule, {
 			}`,
       options: [{ prefer: 'explicit' }],
     },
+
+    // ============================================================
+    // Null targets have distinct Node.js semantics and must be
+    // left alone. A top-level null disables the exports field
+    // (legacy resolution); { ".": null } encapsulates the package
+    // and makes every import fail with ERR_PACKAGE_PATH_NOT_EXPORTED.
+    // ============================================================
+    `{ "exports": null }`,
+    {
+      code: `{ "exports": null }`,
+      options: [{ prefer: 'explicit' }],
+    },
+    {
+      code: `{
+				"exports": {
+					".": null
+				}
+			}`,
+      options: [{ prefer: 'implicit' }],
+    },
   ],
 });

--- a/src/utils/predicates/index.ts
+++ b/src/utils/predicates/index.ts
@@ -1,3 +1,4 @@
+export { isJSONNullLiteral } from './isJSONNullLiteral.ts';
 export { isJSONStringLiteral } from './isJSONStringLiteral.ts';
 export { isNotNullish } from './isNotNullish.ts';
 export { isPackageJson } from './isPackageJson.ts';

--- a/src/utils/predicates/isJSONNullLiteral.ts
+++ b/src/utils/predicates/isJSONNullLiteral.ts
@@ -1,0 +1,5 @@
+import type { AST } from 'jsonc-eslint-parser';
+
+export function isJSONNullLiteral(node: AST.JSONNode): boolean {
+  return node.type === 'JSONLiteral' && node.value === null;
+}


### PR DESCRIPTION
## Problem

`exports-subpaths-style` treats `null` and `{ ".": null }` as equivalent single-root-export formats and autofixes between them. Node.js resolves them differently, so the fix silently changes runtime behavior.

A package sets `"exports": { ".": null }` to encapsulate itself and expose no entry points. With `prefer: "implicit"`, `--fix` rewrites it to `"exports": null`; Node treats a top-level `null` as if the field were absent, so legacy `main` and deep-file imports start resolving again. The default `prefer: "explicit"` mode corrupts the reverse case.

The difference is in Node's resolvers (v24.13.1): a top-level `null` is gated out by [`if (packageConfig.exports != null)`](https://github.com/nodejs/node/blob/v24.13.1/lib/internal/modules/esm/resolve.js#L774) (CJS mirrors it in [`loader.js#L676`](https://github.com/nodejs/node/blob/v24.13.1/lib/internal/modules/cjs/loader.js#L676)) and falls back to legacy resolution. `{ ".": null }` is a non-null object, so the exports path runs and a null target [throws `ERR_PACKAGE_PATH_NOT_EXPORTED`](https://github.com/nodejs/node/blob/v24.13.1/lib/internal/modules/esm/resolve.js#L604). The docs describe [encapsulation when `exports` is defined](https://github.com/nodejs/node/blob/v24.13.1/doc/api/packages.md#L370) and [null targets excluding subpaths](https://github.com/nodejs/node/blob/v24.13.1/doc/api/packages.md#L636).

Closes #2177

## Changes

`null` literal targets are now skipped in both `validateForExplicit` and `validateForImplicit`, so neither mode rewrites them. Non-null targets are unaffected: `{ ".": "./x" }` and `"./x"` still normalize as before.

The obsolete `{ "exports": null }` invalid case moves to `valid`, and implicit-mode coverage for `{ ".": null }` is added.
